### PR TITLE
Add extensive unit tests for path handling

### DIFF
--- a/tests/Unit/AbsolutePathHelpersTest.php
+++ b/tests/Unit/AbsolutePathHelpersTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tests\Unit;
+
+use Orryv\Path;
+use Orryv\Path\Models\AbsoluteAccessPathFormat;
+use PHPUnit\Framework\TestCase;
+
+class AbsolutePathHelpersTest extends TestCase
+{
+    public function testSetBasePathRequiresKnownFolderOrFile(): void
+    {
+        $base = Path::create('/var/www/base');
+        $path = Path::create('/var/www/base/index.php')->asFile();
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Unknown if $base_folder is a folder or a file');
+
+        $path->setBasePath($base);
+    }
+
+    public function testGetNthFolderRejectsUnknownFormatClass(): void
+    {
+        $path = Path::create('/var/www/html/index.php')->asFile();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $path->getNthFolder(0, \stdClass::class);
+    }
+
+    public function testPreserveEndSlashAffectsFolderHelpers(): void
+    {
+        $path = Path::create('C:/Projects/Demo/')->asFolder()->preserveEndSlash();
+
+        $lastFolder = $path->getLastFolder(AbsoluteAccessPathFormat::class);
+
+        $this->assertSame('C:\\Projects\\Demo\\', (string) $lastFolder);
+        $this->assertSame('C:/Projects/Demo/', (string) $path->getLastFolder());
+    }
+
+    public function testCdSupportsArrayCommands(): void
+    {
+        $path = Path::create('/var/www')->asFolder();
+
+        $updated = $path->cd(['foo', '../bar', './baz'])->asFolder();
+
+        $this->assertSame('/var/www/bar/baz', (string) $updated->getReferencePath());
+        $this->assertSame(['var', 'www'], $path->getPath());
+    }
+
+    public function testAsDotTreatsParentSegmentAsFolder(): void
+    {
+        $path = Path::create('https://example.com/path/..')->asDot();
+
+        $this->assertSame(['path', '..'], $path->getPath());
+        $this->assertSame(['path', '..'], $path->getFolderPath());
+    }
+}
+

--- a/tests/Unit/AbsoluteURIPathManipulationTest.php
+++ b/tests/Unit/AbsoluteURIPathManipulationTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tests\Unit;
+
+use Orryv\Path;
+use Orryv\Path\Enums\Encoder;
+use PHPUnit\Framework\TestCase;
+
+class AbsoluteURIPathManipulationTest extends TestCase
+{
+    public function testQueryHelpersRoundTrip(): void
+    {
+        $path = Path::create('https://example.com/assets/image.png?foo=bar&flag')->asFile();
+
+        $this->assertSame(['foo' => 'bar', 'flag' => null], $path->getQuery());
+        $this->assertSame('foo=bar&flag', $path->getQueryString());
+
+        $withoutQuery = $path->rmQuery();
+        $this->assertNull($withoutQuery->getQuery());
+        $this->assertSame('https://example.com/assets/image.png', (string) $withoutQuery->getAccessURI());
+
+        $withQuery = $withoutQuery->withQuery(['page' => '1', 'filter' => null]);
+        $this->assertSame('page=1&filter', $withQuery->getQueryString());
+        $this->assertSame('https://example.com/assets/image.png?page=1&filter', (string) $withQuery->getAccessURI());
+    }
+
+    public function testWithQueryStringParsesValues(): void
+    {
+        $path = Path::create('https://example.com/search')->withQueryString('q=phpunit&debug');
+
+        $this->assertSame(['q' => 'phpunit', 'debug' => null], $path->getQuery());
+        $this->assertSame('https://example.com/search?q=phpunit&debug', (string) $path->getAccessURI());
+    }
+
+    public function testFragmentHelpers(): void
+    {
+        $path = Path::create('https://example.com/docs/index.html#top')->asFile();
+
+        $this->assertSame('top', $path->getFragment());
+
+        $withoutFragment = $path->rmFragment();
+        $this->assertNull($withoutFragment->getFragment());
+        $this->assertSame('https://example.com/docs/index.html', (string) $withoutFragment->getAccessURI());
+
+        $withFragment = $withoutFragment->withFragment('section-2');
+        $this->assertSame('section-2', $withFragment->getFragment());
+        $this->assertSame('https://example.com/docs/index.html#section-2', (string) $withFragment->getAccessURI());
+    }
+
+    public function testUsernameAndPasswordUpdateRootFolder(): void
+    {
+        $path = Path::create('https://example.com/private/area')->asFolder();
+
+        $withUsername = $path->withUsername('alice');
+        $withPassword = $withUsername->withPassword('secret');
+
+        $this->assertSame('alice', $withPassword->getUsername());
+        $this->assertSame('secret', $withPassword->getPassword());
+        $this->assertSame('https://alice:secret@example.com/private/area', (string) $withPassword->getAccessURI());
+    }
+
+    public function testWithPortProducesNewInstance(): void
+    {
+        $path = Path::create('https://example.com/service');
+
+        $withPort = $path->withPort(8443);
+
+        $this->assertNotSame($path, $withPort);
+        $this->assertNull($path->getPort());
+        $this->assertSame(8443, $withPort->getPort());
+    }
+
+    public function testWithEncodingDecodesReferencePath(): void
+    {
+        $path = Path::create('https://example.com/path%20with%20spaces/encoded%2Fsegment')->withEncoding(Encoder::URLENCODE);
+
+        $this->assertSame('https://example.com/path with spaces/encoded/segment', (string) $path->getReferencePath());
+    }
+}
+

--- a/tests/Unit/Models/AbsoluteReferencePathFormatTest.php
+++ b/tests/Unit/Models/AbsoluteReferencePathFormatTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use Orryv\Path\Models\AbsoluteReferencePathFormat;
+use PHPUnit\Framework\TestCase;
+
+class AbsoluteReferencePathFormatTest extends TestCase
+{
+    public function testConvertsWindowsBackslashesToForwardSlashes(): void
+    {
+        $format = new AbsoluteReferencePathFormat('C:\\Projects\\Demo\\file.txt');
+
+        $this->assertSame('C:/Projects/Demo/file.txt', (string) $format);
+    }
+
+    public function testPreservesTrailingSlashWhenRequested(): void
+    {
+        $format = new AbsoluteReferencePathFormat('https://example.com/assets/', true);
+
+        $this->assertSame('https://example.com/assets/', (string) $format);
+    }
+
+    public function testRemovesTrailingSlashWhenNotPreserving(): void
+    {
+        $format = new AbsoluteReferencePathFormat('https://example.com/assets/');
+
+        $this->assertSame('https://example.com/assets', (string) $format);
+    }
+
+    public function testNormalizesUnixFileScheme(): void
+    {
+        $format = new AbsoluteReferencePathFormat('file:///var/log/syslog');
+
+        $this->assertSame('/var/log/syslog', (string) $format);
+    }
+
+    public function testNormalizesGenericUri(): void
+    {
+        $format = new AbsoluteReferencePathFormat('git+ssh://example.com:2222/repo.git');
+
+        $this->assertSame('git+ssh://example.com:2222/repo.git', (string) $format);
+    }
+
+    public function testRejectsRelativePath(): void
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Input path not recognized');
+
+        new AbsoluteReferencePathFormat('path/to/file.txt');
+    }
+
+    public function testWindowsNetworkPathRequiresShareSeparator(): void
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Invalid');
+
+        new AbsoluteReferencePathFormat('file://server');
+    }
+
+    public function testExtractWindowsNetworkPathWithBackslashes(): void
+    {
+        $format = new AbsoluteReferencePathFormat('\\\\Server\\Share\\folder\\file.txt');
+
+        [$prefix, $segments] = $format->extractWindowsNetworkPath('\\\\Server\\Share\\folder\\file.txt');
+
+        $this->assertSame('//Server/', $prefix);
+        $this->assertSame(['Share', 'folder', 'file.txt'], $segments);
+    }
+}
+

--- a/tests/Unit/Models/AccessFormatValidationTest.php
+++ b/tests/Unit/Models/AccessFormatValidationTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use Orryv\Path\Models\AbsoluteAccessPathFormat;
+use Orryv\Path\Models\AbsoluteAccessURIFormat;
+use Orryv\Path\Exceptions\InvalidAbsoluteAccessPathFormatException;
+use Orryv\Path\Exceptions\InvalidAbsoluteAccessURIFormatException;
+use PHPUnit\Framework\TestCase;
+
+class AccessFormatValidationTest extends TestCase
+{
+    public function testAcceptsValidAccessPath(): void
+    {
+        $format = new AbsoluteAccessPathFormat('C:\\Projects\\Demo\\file.txt');
+
+        $this->assertSame('C:\\Projects\\Demo\\file.txt', (string) $format);
+    }
+
+    public function testRejectsRelativeAccessPath(): void
+    {
+        $this->expectException(InvalidAbsoluteAccessPathFormatException::class);
+        $this->expectExceptionMessage('Invalid (absolute) AccessPath');
+
+        new AbsoluteAccessPathFormat('projects/demo/file.txt');
+    }
+
+    public function testAcceptsValidAccessUri(): void
+    {
+        $format = new AbsoluteAccessURIFormat('https://example.com/path/to/file.txt');
+
+        $this->assertSame('https://example.com/path/to/file.txt', (string) $format);
+    }
+
+    public function testRejectsUriWithSpaces(): void
+    {
+        $this->expectException(InvalidAbsoluteAccessURIFormatException::class);
+        $this->expectExceptionMessage('Invalid (absolute) AccessURI');
+
+        new AbsoluteAccessURIFormat('https://example.com/with space');
+    }
+
+    public function testRejectsUriWithBackslashes(): void
+    {
+        $this->expectException(InvalidAbsoluteAccessURIFormatException::class);
+
+        new AbsoluteAccessURIFormat('https://example.com\\with-backslash');
+    }
+}
+

--- a/tests/Unit/PathFactoryTest.php
+++ b/tests/Unit/PathFactoryTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Tests\Unit;
+
+use Orryv\Path;
+use Orryv\Path\Exceptions\InvalidAbsoluteReferencePathFormatException;
+use Orryv\Path\Models\AbsoluteReferencePathFormat;
+use Orryv\Path\Paths\AbsoluteURIPath;
+use Orryv\Path\Paths\AbsoluteUnixPath;
+use Orryv\Path\Paths\AbsoluteWindowsNetworkPath;
+use Orryv\Path\Paths\AbsoluteWindowsPath;
+use PHPUnit\Framework\TestCase;
+
+class PathFactoryTest extends TestCase
+{
+    public function testCreateDetectsHttpUri(): void
+    {
+        $path = Path::create('https://example.com/resource');
+
+        $this->assertInstanceOf(AbsoluteURIPath::class, $path);
+        $this->assertSame('https://example.com/resource', (string) $path->getReferencePath());
+    }
+
+    public function testCreateDetectsGenericUri(): void
+    {
+        $path = Path::create('ftp://files.example.com/archive.tar.gz');
+
+        $this->assertInstanceOf(AbsoluteURIPath::class, $path);
+        $this->assertSame('ftp://files.example.com/archive.tar.gz', (string) $path->getReferencePath());
+    }
+
+    public function testCreateDetectsWindowsDrivePath(): void
+    {
+        $path = Path::create('C:/Windows/System32');
+
+        $this->assertInstanceOf(AbsoluteWindowsPath::class, $path);
+        $this->assertSame('C:/Windows/System32', (string) $path->getReferencePath());
+    }
+
+    public function testCreateDetectsWindowsNetworkPath(): void
+    {
+        $path = Path::create('\\\\Server01\\Share\\Folder');
+
+        $this->assertInstanceOf(AbsoluteWindowsNetworkPath::class, $path);
+        $this->assertSame('file://Server01/Share/Folder', (string) $path->getAccessURI());
+    }
+
+    public function testCreateDetectsUnixPath(): void
+    {
+        $path = Path::create('/var/log/nginx');
+
+        $this->assertInstanceOf(AbsoluteUnixPath::class, $path);
+        $this->assertSame('/var/log/nginx', (string) $path->getReferencePath());
+    }
+
+    public function testCreateTrimsWhitespace(): void
+    {
+        $path = Path::create('   /opt/app/config  ')->asFolder();
+
+        $this->assertSame('/opt/app/config', (string) $path->getReferencePath());
+    }
+
+    public function testCreateRejectsEmptyString(): void
+    {
+        $this->expectException(InvalidAbsoluteReferencePathFormatException::class);
+        $this->expectExceptionMessage('Invalid Path: Empty path');
+
+        Path::create('    ');
+    }
+
+    public function testCreateRejectsInvalidUtf8(): void
+    {
+        $invalid = "https://example.com/resource" . "\xC3\x28";
+
+        $this->expectException(InvalidAbsoluteReferencePathFormatException::class);
+        $this->expectExceptionMessage('Invalid Path: The path is not a valid UTF-8 string');
+
+        Path::create($invalid);
+    }
+
+    public function testHttpUriDetectionHelpers(): void
+    {
+        $http = new AbsoluteReferencePathFormat('https://example.com/path');
+        $generic = new AbsoluteReferencePathFormat('git+ssh://example.com/repo.git');
+
+        $this->assertTrue(Path::isHTTPURI($http));
+        $this->assertFalse(Path::isHTTPURI($generic));
+    }
+
+    public function testGenericUriDetectionHelperExcludesHttp(): void
+    {
+        $http = new AbsoluteReferencePathFormat('http://example.com');
+        $generic = new AbsoluteReferencePathFormat('s3://bucket/object');
+
+        $this->assertFalse(Path::isGenericURI($http));
+        $this->assertTrue(Path::isGenericURI($generic));
+    }
+
+    public function testWindowsPathDetectionHelper(): void
+    {
+        $windows = new AbsoluteReferencePathFormat('C:/Program Files');
+        $unix = new AbsoluteReferencePathFormat('/var/log');
+
+        $this->assertTrue(Path::isWindowsPath($windows));
+        $this->assertFalse(Path::isWindowsPath($unix));
+    }
+
+    public function testWindowsNetworkPathDetectionSupportsUnicodeHosts(): void
+    {
+        $network = new AbsoluteReferencePathFormat('//Tésté/Share/Folder');
+
+        $this->assertTrue(Path::isWindowsNetworkPath($network));
+    }
+
+    public function testUnixPathDetectionRejectsNetworkShares(): void
+    {
+        $network = new AbsoluteReferencePathFormat('//server/share');
+        $unix = new AbsoluteReferencePathFormat('/usr/bin');
+
+        $this->assertFalse(Path::isUnixPath($network));
+        $this->assertTrue(Path::isUnixPath($unix));
+    }
+}
+


### PR DESCRIPTION
## Summary
- add unit tests for the `Path::create` factory and helper detection methods
- cover normalization/validation edge cases for reference and access format value objects
- exercise URI/path helper behaviours including navigation, query/fragment handling, and trailing separator preservation

## Testing
- vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68c9d42b5b8c832f86ee33c71a9b95c0