### PR TITLE
Add comprehensive integration tests for path operations

### DIFF
--- a/tests/Integration/FilesystemNavigationExtendedTest.php
+++ b/tests/Integration/FilesystemNavigationExtendedTest.php
@@ -1,0 +1,239 @@
+<?php
+
+namespace Tests\Integration;
+
+use Orryv\Path;
+use Orryv\Path\DirectoryPath;
+use Orryv\Path\Enums\PathFormat;
+use Orryv\Path\Exceptions\DifferentOriginException;
+use Orryv\Path\FilePath;
+use OutOfBoundsException;
+use PHPUnit\Framework\TestCase;
+
+class FilesystemNavigationExtendedTest extends TestCase
+{
+    /**
+     * @dataProvider fileCdProvider
+     */
+    public function testFileCdResolvesRelativeInputs(string $relative, string $expectedReference, string $expectedAccess, string $expectedClass): void
+    {
+        $file = Path::file('C:/Projects/app/index.php', PathFormat::REFERENCE_PATH);
+
+        $result = $file->cd($relative);
+
+        $this->assertInstanceOf($expectedClass, $result);
+        $this->assertSame($expectedReference, $result->toString(PathFormat::REFERENCE_PATH));
+        $this->assertSame($expectedAccess, $result->toString(PathFormat::ACCESS_PATH));
+    }
+
+    public static function fileCdProvider(): iterable
+    {
+        yield 'parent directory' => ['..', 'C:/Projects/app/', 'C:\\Projects\\app\\', DirectoryPath::class];
+        yield 'current directory as explicit directory' => ['./', 'C:/Projects/app/', 'C:\\Projects\\app\\', DirectoryPath::class];
+        yield 'nested file inside current directory' => ['config/app.php', 'C:/Projects/app/config/app.php', 'C:\\Projects\\app\\config\\app.php', FilePath::class];
+        yield 'sibling directory with explicit trailing slash' => ['../logs/', 'C:/Projects/app/logs/', 'C:\\Projects\\app\\logs\\', DirectoryPath::class];
+        yield 'ascend twice before descending' => ['../../shared/bootstrap.php', 'C:/Projects/shared/bootstrap.php', 'C:\\Projects\\shared\\bootstrap.php', FilePath::class];
+        yield 'mixed separators are normalised' => ['..\\cache\\', 'C:/Projects/app/cache/', 'C:\\Projects\\app\\cache\\', DirectoryPath::class];
+        yield 'absolute navigation stays on drive root' => ['/', 'C:/', 'C:\\', DirectoryPath::class];
+    }
+
+    /**
+     * @dataProvider directoryCdProvider
+     */
+    public function testDirectoryCdResolvesRelativeInputs(string $relative, string $expectedReference, string $expectedAccess): void
+    {
+        $directory = Path::dir('//server/share/team/reports/2023/', PathFormat::REFERENCE_PATH);
+
+        $result = $directory->cd($relative);
+
+        $this->assertInstanceOf(DirectoryPath::class, $result);
+        $this->assertSame($expectedReference, $result->toString(PathFormat::REFERENCE_PATH));
+        $this->assertSame($expectedAccess, $result->toString(PathFormat::ACCESS_PATH));
+    }
+
+    public static function directoryCdProvider(): iterable
+    {
+        yield 'step up one level' => ['..', '//server/share/team/reports/', '\\server\\share\\team\\reports\\'];
+        yield 'step up two levels' => ['../..', '//server/share/team/', '\\server\\share\\team\\'];
+        yield 'switch to sibling year directory' => ['../2022/', '//server/share/team/reports/2022/', '\\server\\share\\team\\reports\\2022\\'];
+        yield 'treat dotted name as directory' => ['../../archive.zip', '//server/share/team/archive.zip/', '\\server\\share\\team\\archive.zip\\'];
+        yield 'jump to share root' => ['/', '//server/share/', '\\server\\share\\'];
+    }
+
+    /**
+     * @dataProvider cdOutOfBoundsProvider
+     */
+    public function testCdThrowsWhenNavigatingAboveRoot(callable $factory, string $relative): void
+    {
+        $path = $factory();
+
+        $this->expectException(OutOfBoundsException::class);
+        $path->cd($relative);
+    }
+
+    public static function cdOutOfBoundsProvider(): iterable
+    {
+        yield 'file path cannot ascend above drive root' => [
+            static fn () => Path::file('C:/Projects/app/index.php', PathFormat::REFERENCE_PATH),
+            '../../../..',
+        ];
+        yield 'unc directory cannot go above share root' => [
+            static fn () => Path::dir('//server/share/', PathFormat::REFERENCE_PATH),
+            '..',
+        ];
+    }
+
+    /**
+     * @dataProvider cdBaseDirViolationProvider
+     */
+    public function testCdWithBaseDirPreventsEscape(callable $factory, string $relative): void
+    {
+        $path = $factory();
+
+        $this->expectException(OutOfBoundsException::class);
+        $path->cd($relative);
+    }
+
+    public static function cdBaseDirViolationProvider(): iterable
+    {
+        yield 'file path cannot leave configured base directory' => [
+            static function () {
+                $base = Path::dir('C:/Projects/app/storage/', PathFormat::REFERENCE_PATH);
+
+                return Path::file('C:/Projects/app/storage/logs/error.log', PathFormat::REFERENCE_PATH)->withBaseDir($base);
+            },
+            '../../..',
+        ];
+        yield 'directory path blocked at base boundary' => [
+            static function () {
+                $base = Path::dir('C:/Projects/app/storage/', PathFormat::REFERENCE_PATH);
+
+                return Path::dir('C:/Projects/app/storage/logs/', PathFormat::REFERENCE_PATH)->withBaseDir($base);
+            },
+            '../..',
+        ];
+    }
+
+    /**
+     * @dataProvider cdWithBaseDirProvider
+     */
+    public function testCdWithBaseDirAllowsAbsoluteNavigation(callable $factory, string $relative, string $expectedReference, string $expectedAccess, string $expectedClass): void
+    {
+        $path = $factory();
+
+        $result = $path->cd($relative);
+
+        $this->assertInstanceOf($expectedClass, $result);
+        $this->assertSame($expectedReference, $result->toString(PathFormat::REFERENCE_PATH));
+        $this->assertSame($expectedAccess, $result->toString(PathFormat::ACCESS_PATH));
+    }
+
+    public static function cdWithBaseDirProvider(): iterable
+    {
+        yield 'file path respects base root when using absolute navigation' => [
+            static function () {
+                $base = Path::dir('C:/Projects/app/', PathFormat::REFERENCE_PATH);
+
+                return Path::file('C:/Projects/app/storage/logs/error.log', PathFormat::REFERENCE_PATH)->withBaseDir($base);
+            },
+            '/config/app.php',
+            'C:/Projects/app/config/app.php',
+            'C:/Projects/app/config/app.php',
+            FilePath::class,
+        ];
+        yield 'unc directory absolute navigation stays inside base' => [
+            static function () {
+                $base = Path::dir('//server/share/app/', PathFormat::REFERENCE_PATH);
+
+                return Path::dir('//server/share/app/releases/2024/', PathFormat::REFERENCE_PATH)->withBaseDir($base);
+            },
+            '/logs/',
+            '//server/share/app/logs/',
+            '\\\\server\\share\\app\\logs\\',
+            DirectoryPath::class,
+        ];
+    }
+
+    public function testFileCdEmptyStringReturnsParentDirectory(): void
+    {
+        $file = Path::file('/var/www/html/index.php', PathFormat::REFERENCE_PATH);
+
+        $directory = $file->cd('');
+
+        $this->assertInstanceOf(DirectoryPath::class, $directory);
+        $this->assertSame('/var/www/html/', $directory->toString(PathFormat::REFERENCE_PATH));
+        $this->assertSame('/var/www/html/', $directory->toString(PathFormat::ACCESS_PATH));
+    }
+
+    public function testDirectoryCdEmptyStringReturnsSameInstance(): void
+    {
+        $directory = Path::dir('/var/www/html/', PathFormat::REFERENCE_PATH);
+
+        $result = $directory->cd('');
+
+        $this->assertSame($directory, $result);
+    }
+
+    public function testWithBaseDirRejectsDifferentOrigin(): void
+    {
+        $base = Path::dir('//server/share/app/', PathFormat::REFERENCE_PATH);
+        $file = Path::file('C:/Projects/app/index.php', PathFormat::REFERENCE_PATH);
+
+        $this->expectException(DifferentOriginException::class);
+        $file->withBaseDir($base);
+    }
+
+    public function testWithBaseDirRejectsPathOutsideBase(): void
+    {
+        $base = Path::dir('C:/Projects/app/storage/', PathFormat::REFERENCE_PATH);
+        $file = Path::file('C:/Projects/app/config/app.php', PathFormat::REFERENCE_PATH);
+
+        $this->expectException(OutOfBoundsException::class);
+        $file->withBaseDir($base);
+    }
+
+    /**
+     * @dataProvider withDirectoryProvider
+     */
+    public function testWithDirectoryReplacesParentSegments(callable $factory, string|DirectoryPath $directory, string $expectedReference, string $expectedAccess): void
+    {
+        $file = $factory();
+
+        $moved = $file->withDirectory($directory);
+
+        $this->assertInstanceOf(FilePath::class, $moved);
+        $this->assertSame($expectedReference, $moved->toString(PathFormat::REFERENCE_PATH));
+        $this->assertSame($expectedAccess, $moved->toString(PathFormat::ACCESS_PATH));
+    }
+
+    public static function withDirectoryProvider(): iterable
+    {
+        yield 'switch to resources directory' => [
+            static fn () => Path::file('C:/Projects/app/src/bootstrap.php', PathFormat::REFERENCE_PATH),
+            Path::dir('C:/Projects/app/resources/views/', PathFormat::REFERENCE_PATH),
+            'C:/Projects/app/resources/views/bootstrap.php',
+            'C:\\Projects\\app\\resources\\views\\bootstrap.php',
+        ];
+        yield 'accepts string directory input' => [
+            static fn () => Path::file('C:/Projects/app/src/bootstrap.php', PathFormat::REFERENCE_PATH),
+            'C:/Projects/app/public/',
+            'C:/Projects/app/public/bootstrap.php',
+            'C:\\Projects\\app\\public\\bootstrap.php',
+        ];
+        yield 'works with unc paths' => [
+            static fn () => Path::file('//server/share/app/bin/run.exe', PathFormat::REFERENCE_PATH),
+            Path::dir('//server/share/app/tools/', PathFormat::REFERENCE_PATH),
+            '//server/share/app/tools/run.exe',
+            '\\server\\share\\app\\tools\\run.exe',
+        ];
+    }
+
+    public function testWithDirectoryRejectsDifferentOrigin(): void
+    {
+        $file = Path::file('C:/Projects/app/index.php', PathFormat::REFERENCE_PATH);
+        $directory = Path::dir('//server/share/app/', PathFormat::REFERENCE_PATH);
+
+        $this->expectException(DifferentOriginException::class);
+        $file->withDirectory($directory);
+    }
+}

--- a/tests/Integration/FilesystemRelativePathIntegrationTest.php
+++ b/tests/Integration/FilesystemRelativePathIntegrationTest.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace Tests\Integration;
+
+use Orryv\Path;
+use Orryv\Path\DirectoryPath;
+use Orryv\Path\Enums\PathFormat;
+use Orryv\Path\Exceptions\DifferentOriginException;
+use Orryv\Path\FilePath;
+use PHPUnit\Framework\TestCase;
+
+class FilesystemRelativePathIntegrationTest extends TestCase
+{
+    /**
+     * @dataProvider relativeFromProvider
+     */
+    public function testGetRelativePathFromProducesExpectedSegments(callable $factory, string|DirectoryPath|FilePath $base, PathFormat $format, string $expected): void
+    {
+        $path = $factory();
+
+        $this->assertSame($expected, $path->getRelativePathFrom($base, $format));
+    }
+
+    public static function relativeFromProvider(): iterable
+    {
+        yield 'windows file from project root directory' => [
+            static fn () => Path::file('C:/Projects/app/config/app.php', PathFormat::REFERENCE_PATH),
+            'C:/Projects/app/',
+            PathFormat::REFERENCE_PATH,
+            'config/app.php',
+        ];
+        yield 'windows file from nested storage directory' => [
+            static fn () => Path::file('C:/Projects/app/config/app.php', PathFormat::REFERENCE_PATH),
+            'C:/Projects/app/storage/logs/',
+            PathFormat::REFERENCE_PATH,
+            '../../config/app.php',
+        ];
+        yield 'unc directory using access separators' => [
+            static fn () => Path::dir('//server/share/app/releases/2024/', PathFormat::REFERENCE_PATH),
+            '//server/share/app/',
+            PathFormat::ACCESS_PATH,
+            'releases\\2024',
+        ];
+        yield 'posix sibling file path' => [
+            static fn () => Path::file('/var/www/html/index.php', PathFormat::REFERENCE_PATH),
+            Path::file('/var/www/html/css/app.css', PathFormat::REFERENCE_PATH),
+            PathFormat::REFERENCE_PATH,
+            '../index.php',
+        ];
+        yield 'unc file from nested base directory' => [
+            static fn () => Path::file('//server/share/app/tools/run.exe', PathFormat::REFERENCE_PATH),
+            '//server/share/app/releases/2024/',
+            PathFormat::REFERENCE_PATH,
+            '../../tools/run.exe',
+        ];
+        yield 'access uri format keeps logical separators' => [
+            static fn () => Path::file('/var/www/html/assets/img/logo.svg', PathFormat::REFERENCE_PATH),
+            Path::dir('/var/www/html/', PathFormat::REFERENCE_PATH),
+            PathFormat::ACCESS_URI,
+            'assets/img/logo.svg',
+        ];
+        yield 'unicode segments are preserved' => [
+            static fn () => Path::file('C:/Projects/app/Ångström/config.ini', PathFormat::REFERENCE_PATH),
+            'C:/Projects/app/',
+            PathFormat::REFERENCE_PATH,
+            'Ångström/config.ini',
+        ];
+    }
+
+    public function testGetRelativePathFromThrowsOnDifferentOrigins(): void
+    {
+        $path = Path::file('C:/Projects/app/index.php', PathFormat::REFERENCE_PATH);
+
+        $this->expectException(DifferentOriginException::class);
+        $path->getRelativePathFrom('//server/share/app/', PathFormat::REFERENCE_PATH);
+    }
+
+    /**
+     * @dataProvider relativePairProvider
+     */
+    public function testGetRelativePathToMatchesInverse(callable $baseFactory, callable $targetFactory, string $expected): void
+    {
+        $base = $baseFactory();
+        $target = $targetFactory();
+
+        $this->assertSame($expected, $base->getRelativePathTo($target, PathFormat::REFERENCE_PATH));
+        $this->assertSame($expected, $target->getRelativePathFrom($base, PathFormat::REFERENCE_PATH));
+    }
+
+    public static function relativePairProvider(): iterable
+    {
+        yield 'windows directory to file' => [
+            static fn () => Path::dir('C:/Projects/app/', PathFormat::REFERENCE_PATH),
+            static fn () => Path::file('C:/Projects/app/config/app.php', PathFormat::REFERENCE_PATH),
+            'config/app.php',
+        ];
+        yield 'unc release directory to tool executable' => [
+            static fn () => Path::dir('//server/share/app/releases/2023/', PathFormat::REFERENCE_PATH),
+            static fn () => Path::file('//server/share/app/tools/run.exe', PathFormat::REFERENCE_PATH),
+            '../../tools/run.exe',
+        ];
+        yield 'posix file to document root' => [
+            static fn () => Path::file('/var/www/html/css/app.css', PathFormat::REFERENCE_PATH),
+            static fn () => Path::file('/var/www/html/index.php', PathFormat::REFERENCE_PATH),
+            '../index.php',
+        ];
+    }
+
+    /**
+     * @dataProvider commonBaseProvider
+     */
+    public function testGetCommonBasePathReturnsExpectedDirectories(callable $firstFactory, callable $secondFactory, PathFormat $format, string $expectedReference, string $expectedAccess): void
+    {
+        $first = $firstFactory();
+        $second = $secondFactory();
+
+        $common = $first->getCommonBasePath($second, $format);
+
+        $this->assertInstanceOf(DirectoryPath::class, $common);
+        $this->assertSame($expectedReference, $common->toString(PathFormat::REFERENCE_PATH));
+        $this->assertSame($expectedAccess, $common->toString(PathFormat::ACCESS_PATH));
+    }
+
+    public static function commonBaseProvider(): iterable
+    {
+        yield 'windows files share project directory' => [
+            static fn () => Path::file('C:/Projects/app/storage/logs/error.log', PathFormat::REFERENCE_PATH),
+            static fn () => Path::file('C:/Projects/app/config/app.php', PathFormat::REFERENCE_PATH),
+            PathFormat::REFERENCE_PATH,
+            'C:/Projects/app/',
+            'C:\\Projects\\app\\',
+        ];
+        yield 'unc directories share releases folder' => [
+            static fn () => Path::dir('//server/share/app/releases/2024/', PathFormat::REFERENCE_PATH),
+            static fn () => Path::dir('//server/share/app/releases/2023/', PathFormat::REFERENCE_PATH),
+            PathFormat::ACCESS_PATH,
+            '//server/share/app/releases/',
+            '\\server\\share\\app\\releases\\',
+        ];
+        yield 'posix files share /var/www' => [
+            static fn () => Path::file('/var/www/html/index.php', PathFormat::REFERENCE_PATH),
+            static fn () => Path::file('/var/www/assets/app.js', PathFormat::REFERENCE_PATH),
+            PathFormat::REFERENCE_PATH,
+            '/var/www/',
+            '/var/www/',
+        ];
+    }
+
+    public function testGetCommonBasePathRejectsDifferentOrigin(): void
+    {
+        $first = Path::file('C:/Projects/app/index.php', PathFormat::REFERENCE_PATH);
+        $second = Path::file('//server/share/app/index.php', PathFormat::REFERENCE_PATH);
+
+        $this->expectException(DifferentOriginException::class);
+        $first->getCommonBasePath($second, PathFormat::REFERENCE_PATH);
+    }
+}

--- a/tests/Integration/UrlPathAdvancedIntegrationTest.php
+++ b/tests/Integration/UrlPathAdvancedIntegrationTest.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace Tests\Integration;
+
+use InvalidArgumentException;
+use Orryv\Path;
+use Orryv\Path\Enums\PathFormat;
+use OutOfBoundsException;
+use PHPUnit\Framework\TestCase;
+
+class UrlPathAdvancedIntegrationTest extends TestCase
+{
+    /**
+     * @dataProvider relativeHrefProvider
+     */
+    public function testCdResolvesRelativeHrefs(string $relative, string $expectedReference, string $expectedAccess): void
+    {
+        $url = Path::url('https://example.com/app/assets/images/logo.png?version=1#top', PathFormat::REFERENCE_PATH);
+
+        $result = $url->cd($relative);
+
+        $this->assertSame($expectedReference, $result->toString(PathFormat::REFERENCE_PATH));
+        $this->assertSame($expectedAccess, $result->toString(PathFormat::ACCESS_URI));
+    }
+
+    public static function relativeHrefProvider(): iterable
+    {
+        yield 'navigate to sibling css asset with query and fragment' => [
+            '../css/app.css?version=2#header',
+            'https://example.com/app/assets/css/app.css?version=2#header',
+            'https://example.com/app/assets/css/app.css?version=2#header',
+        ];
+        yield 'move up two levels before descending' => [
+            '../../scripts/app.js',
+            'https://example.com/app/scripts/app.js',
+            'https://example.com/app/scripts/app.js',
+        ];
+        yield 'preserve spaces while encoding access uri' => [
+            '../fonts/Open Sans.woff2',
+            'https://example.com/app/assets/fonts/Open Sans.woff2',
+            'https://example.com/app/assets/fonts/Open%20Sans.woff2',
+        ];
+    }
+
+    public function testCdWithQueryStringReplacesQueryAndClearsFragment(): void
+    {
+        $url = Path::url('https://example.com/app/assets/images/logo.png?version=1#top', PathFormat::REFERENCE_PATH);
+
+        $updated = $url->cd('?version=3');
+
+        $this->assertSame('https://example.com/app/assets/images/logo.png?version=3', $updated->toString(PathFormat::REFERENCE_PATH));
+        $this->assertSame('https://example.com/app/assets/images/logo.png?version=3', $updated->toString(PathFormat::ACCESS_URI));
+    }
+
+    public function testCdWithFragmentOnlyUpdatesFragment(): void
+    {
+        $url = Path::url('https://example.com/app/assets/images/logo.png?version=1', PathFormat::REFERENCE_PATH);
+
+        $updated = $url->cd('#footer');
+
+        $this->assertSame('https://example.com/app/assets/images/logo.png?version=1#footer', $updated->toString(PathFormat::REFERENCE_PATH));
+        $this->assertSame('https://example.com/app/assets/images/logo.png?version=1#footer', $updated->toString(PathFormat::ACCESS_URI));
+    }
+
+    public function testCdWithEmptyHrefRemovesFragment(): void
+    {
+        $url = Path::url('https://example.com/app/assets/images/logo.png?version=1#top', PathFormat::REFERENCE_PATH);
+
+        $updated = $url->cd('');
+
+        $this->assertSame('https://example.com/app/assets/images/logo.png?version=1', $updated->toString(PathFormat::REFERENCE_PATH));
+    }
+
+    public function testWithBaseDirRejectsPathWithoutTrailingSlash(): void
+    {
+        $url = Path::url('https://example.com/app/assets/css/app.css', PathFormat::REFERENCE_PATH);
+
+        $this->expectException(InvalidArgumentException::class);
+        $url->withBaseDir('https://example.com/app');
+    }
+
+    public function testWithBaseDirPreventsEscapingOrigin(): void
+    {
+        $base = Path::url('https://example.com/app/', PathFormat::REFERENCE_PATH);
+        $asset = Path::url('https://example.com/app/assets/css/app.css', PathFormat::REFERENCE_PATH)->withBaseDir($base);
+
+        $this->expectException(OutOfBoundsException::class);
+        $asset->cd('https://cdn.example.com/app.css');
+    }
+
+    public function testWithQueryArrayProducesExpectedStrings(): void
+    {
+        $url = Path::url('https://example.com/app/report', PathFormat::REFERENCE_PATH);
+
+        $withQuery = $url->withQuery([
+            'filter' => 'new',
+            'tags' => ['php', 'path'],
+        ]);
+
+        $this->assertSame('https://example.com/app/report?filter=new&tags[0]=php&tags[1]=path', $withQuery->toString(PathFormat::REFERENCE_PATH));
+        $this->assertSame('https://example.com/app/report?filter=new&tags%5B0%5D=php&tags%5B1%5D=path', $withQuery->toString(PathFormat::ACCESS_URI));
+    }
+
+    public function testWithoutQueryRemovesSpecificKeys(): void
+    {
+        $url = Path::url('https://example.com/app/report?filter=new&tags%5B0%5D=php&tags%5B1%5D=path', PathFormat::ACCESS_URI);
+
+        $updated = $url->withoutQuery(['filter']);
+
+        $this->assertSame('https://example.com/app/report?tags[0]=php&tags[1]=path', $updated->toString(PathFormat::REFERENCE_PATH));
+        $this->assertSame('https://example.com/app/report?tags%5B0%5D=php&tags%5B1%5D=path', $updated->toString(PathFormat::ACCESS_URI));
+    }
+
+    public function testWithoutQueryClearsAllWhenNull(): void
+    {
+        $url = Path::url('https://example.com/app/report?filter=new', PathFormat::REFERENCE_PATH);
+
+        $cleared = $url->withoutQuery();
+
+        $this->assertSame('https://example.com/app/report', $cleared->toString(PathFormat::REFERENCE_PATH));
+    }
+
+    /**
+     * @dataProvider urlRelativeProvider
+     */
+    public function testGetRelativePathBetweenUrls(string $baseUrl, string $targetUrl, string $expectedReference, string $expectedAccess): void
+    {
+        $base = Path::url($baseUrl, PathFormat::REFERENCE_PATH);
+        $target = Path::url($targetUrl, PathFormat::REFERENCE_PATH);
+
+        $this->assertSame($expectedReference, $base->getRelativePathTo($target, PathFormat::REFERENCE_PATH));
+        $this->assertSame($expectedReference, $target->getRelativePathFrom($base, PathFormat::REFERENCE_PATH));
+        $this->assertSame($expectedAccess, $base->getRelativePathTo($target, PathFormat::ACCESS_URI));
+        $this->assertSame($expectedAccess, $target->getRelativePathFrom($base, PathFormat::ACCESS_URI));
+    }
+
+    public static function urlRelativeProvider(): iterable
+    {
+        yield 'base directory to nested asset' => [
+            'https://example.com/app/',
+            'https://example.com/app/assets/css/app.css',
+            'assets/css/app.css',
+            'assets/css/app.css',
+        ];
+        yield 'dashboard to sibling asset' => [
+            'https://example.com/app/dashboard/',
+            'https://example.com/app/assets/css/app.css',
+            '../assets/css/app.css',
+            '../assets/css/app.css',
+        ];
+        yield 'encode spaces for access uri relative paths' => [
+            'https://example.com/app/assets/images/',
+            'https://example.com/app/assets/fonts/Open Sans.woff2',
+            '../fonts/Open Sans.woff2',
+            '../fonts/Open%20Sans.woff2',
+        ];
+    }
+
+    /**
+     * @dataProvider commonUrlBaseProvider
+     */
+    public function testGetCommonBasePathForUrls(string $first, string $second, string $expectedReference): void
+    {
+        $a = Path::url($first, PathFormat::REFERENCE_PATH);
+        $b = Path::url($second, PathFormat::REFERENCE_PATH);
+
+        $common = $a->getCommonBasePath($b, PathFormat::REFERENCE_PATH);
+
+        $this->assertSame($expectedReference, $common->toString(PathFormat::REFERENCE_PATH));
+        $this->assertSame($expectedReference, $common->toString(PathFormat::ACCESS_URI));
+    }
+
+    public static function commonUrlBaseProvider(): iterable
+    {
+        yield 'shared application root' => [
+            'https://example.com/app/assets/css/app.css',
+            'https://example.com/app/api/v1/index.json',
+            'https://example.com/app/',
+        ];
+        yield 'shared releases directory' => [
+            'https://example.com/app/releases/2024/index.html',
+            'https://example.com/app/releases/2023/notes.html',
+            'https://example.com/app/releases/',
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- add filesystem navigation integration coverage, including relative cd scenarios, base directory enforcement, and directory reassignment
- add relative path integration tests that validate getRelativePathFrom/To and getCommonBasePath across formats
- add advanced URL path integration tests for navigation, query manipulation, and shared base calculation

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68f9627c7a9c832fbceadcc5b357903b