### PR TITLE
Add integration coverage for path formatting and queries

### DIFF
--- a/tests/Integration/FilesystemRelativeFormattingExtendedTest.php
+++ b/tests/Integration/FilesystemRelativeFormattingExtendedTest.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Tests\Integration;
+
+use Orryv\Path;
+use Orryv\Path\DirectoryPath;
+use Orryv\Path\Enums\PathFormat;
+use Orryv\Path\FilePath;
+use PHPUnit\Framework\TestCase;
+
+class FilesystemRelativeFormattingExtendedTest extends TestCase
+{
+    /**
+     * @dataProvider relativeUriProvider
+     */
+    public function testRelativePathFromAccessUriEncodesSegments(callable $factory, string|DirectoryPath|FilePath $base, string $expected): void
+    {
+        $path = $factory();
+
+        $this->assertSame($expected, $path->getRelativePathFrom($base, PathFormat::ACCESS_URI));
+    }
+
+    public static function relativeUriProvider(): iterable
+    {
+        yield 'windows file with space in segment' => [
+            static fn () => Path::file('C:/Projects/App/data/report final.txt', PathFormat::REFERENCE_PATH),
+            'C:/Projects/App/',
+            'data/report final.txt',
+        ];
+
+        yield 'windows file with unicode segment' => [
+            static fn () => Path::file('C:/Projects/App/Δelta/config.ini', PathFormat::REFERENCE_PATH),
+            Path::dir('C:/Projects/App/', PathFormat::REFERENCE_PATH),
+            'Δelta/config.ini',
+        ];
+
+        yield 'unc file with space in share segment' => [
+            static fn () => Path::file('//server/share/QA Reports/summary.docx', PathFormat::REFERENCE_PATH),
+            '//server/share/',
+            'QA Reports/summary.docx',
+        ];
+
+        yield 'unc file with unicode characters' => [
+            static fn () => Path::file('//server/share/data/Δelta/report.csv', PathFormat::REFERENCE_PATH),
+            Path::dir('//server/share/data/', PathFormat::REFERENCE_PATH),
+            'Δelta/report.csv',
+        ];
+
+        yield 'posix file with spaces and unicode characters' => [
+            static fn () => Path::file('/var/www/My Site/über uns.html', PathFormat::REFERENCE_PATH),
+            '/var/www/',
+            'My Site/über uns.html',
+        ];
+
+        yield 'identical directory renders empty relative path' => [
+            static fn () => Path::dir('/var/www/html/', PathFormat::REFERENCE_PATH),
+            Path::dir('/var/www/html/', PathFormat::REFERENCE_PATH),
+            '',
+        ];
+    }
+
+    /**
+     * @dataProvider relativeAccessProvider
+     */
+    public function testRelativePathFromAccessPathUsesNativeSeparators(callable $factory, string|DirectoryPath|FilePath $base, string $expected): void
+    {
+        $path = $factory();
+
+        $this->assertSame($expected, $path->getRelativePathFrom($base, PathFormat::ACCESS_PATH));
+    }
+
+    public static function relativeAccessProvider(): iterable
+    {
+        yield 'windows file preserves backslashes' => [
+            static fn () => Path::file('C:/Projects/App/data/report final.txt', PathFormat::REFERENCE_PATH),
+            'C:/Projects/App/',
+            'data/report final.txt',
+        ];
+
+        yield 'windows unicode segment keeps native separator' => [
+            static fn () => Path::file('C:/Projects/App/Δelta/config.ini', PathFormat::REFERENCE_PATH),
+            Path::dir('C:/Projects/App/', PathFormat::REFERENCE_PATH),
+            'Δelta/config.ini',
+        ];
+
+        yield 'unc path uses backslash separators' => [
+            static fn () => Path::file('//server/share/QA Reports/summary.docx', PathFormat::REFERENCE_PATH),
+            '//server/share/',
+            'QA Reports\\summary.docx',
+        ];
+
+        yield 'posix path keeps forward slashes' => [
+            static fn () => Path::file('/var/www/My Site/über uns.html', PathFormat::REFERENCE_PATH),
+            '/var/www/',
+            'My Site/über uns.html',
+        ];
+
+        yield 'identical directories produce empty string' => [
+            static fn () => Path::dir('/var/www/html/', PathFormat::REFERENCE_PATH),
+            Path::dir('/var/www/html/', PathFormat::REFERENCE_PATH),
+            '',
+        ];
+    }
+
+    /**
+     * @dataProvider commonBaseUriProvider
+     */
+    public function testGetCommonBasePathRendersAccessUri(callable $firstFactory, callable $secondFactory, string $expectedUri): void
+    {
+        $first = $firstFactory();
+        $second = $secondFactory();
+
+        $common = $first->getCommonBasePath($second, PathFormat::ACCESS_URI);
+
+        $this->assertSame($expectedUri, $common->toString(PathFormat::ACCESS_URI));
+    }
+
+    public static function commonBaseUriProvider(): iterable
+    {
+        yield 'windows files share project directory' => [
+            static fn () => Path::file('C:/Projects/App/src/index.php', PathFormat::REFERENCE_PATH),
+            static fn () => Path::file('C:/Projects/App/tests/AppTest.php', PathFormat::REFERENCE_PATH),
+            'file:///C:/Projects/App/',
+        ];
+
+        yield 'unc files share application directory' => [
+            static fn () => Path::file('//server/share/app/releases/2024/build.zip', PathFormat::REFERENCE_PATH),
+            static fn () => Path::file('//server/share/app/config/app.json', PathFormat::REFERENCE_PATH),
+            'file://server/share/app/',
+        ];
+
+        yield 'posix files share /var/www' => [
+            static fn () => Path::file('/var/www/html/index.php', PathFormat::REFERENCE_PATH),
+            static fn () => Path::file('/var/www/assets/app.js', PathFormat::REFERENCE_PATH),
+            'file:///var/www/',
+        ];
+    }
+}

--- a/tests/Integration/FilesystemRenderingConformanceTest.php
+++ b/tests/Integration/FilesystemRenderingConformanceTest.php
@@ -1,0 +1,200 @@
+<?php
+
+namespace Tests\Integration;
+
+use Orryv\Path;
+use Orryv\Path\Enums\PathFormat;
+use PHPUnit\Framework\TestCase;
+
+class FilesystemRenderingConformanceTest extends TestCase
+{
+    /**
+     * @dataProvider directoryRenderingProvider
+     */
+    public function testDirectoryRenderingAcrossFormats(string $input, PathFormat $format, array $expected): void
+    {
+        $directory = Path::dir($input, $format);
+
+        $this->assertSame($expected['reference'], $directory->toString(PathFormat::REFERENCE_PATH));
+        $this->assertSame($expected['access'], $directory->toString(PathFormat::ACCESS_PATH));
+        $this->assertSame($expected['uri'], $directory->toString(PathFormat::ACCESS_URI));
+    }
+
+    public static function directoryRenderingProvider(): iterable
+    {
+        yield 'windows directory preserves trailing slash from reference path' => [
+            'C:/Program Files/App/',
+            PathFormat::REFERENCE_PATH,
+            [
+                'reference' => 'C:/Program Files/App/',
+                'access' => 'C:\\Program Files\\App\\',
+                'uri' => 'file:///C:/Program%20Files/App/',
+            ],
+        ];
+
+        yield 'windows directory without trailing slash stays compact' => [
+            'C:/Workspace',
+            PathFormat::REFERENCE_PATH,
+            [
+                'reference' => 'C:/Workspace',
+                'access' => 'C:\\Workspace',
+                'uri' => 'file:///C:/Workspace',
+            ],
+        ];
+
+        yield 'posix directory keeps separators across formats' => [
+            '/var/www/html/',
+            PathFormat::REFERENCE_PATH,
+            [
+                'reference' => '/var/www/html/',
+                'access' => '/var/www/html/',
+                'uri' => 'file:///var/www/html/',
+            ],
+        ];
+
+        yield 'posix directory without trailing slash does not add one' => [
+            '/usr/local/bin',
+            PathFormat::ACCESS_PATH,
+            [
+                'reference' => '/usr/local/bin',
+                'access' => '/usr/local/bin',
+                'uri' => 'file:///usr/local/bin',
+            ],
+        ];
+
+        yield 'unc directory from reference path renders expected formats' => [
+            '//server/share/releases/2024/',
+            PathFormat::REFERENCE_PATH,
+            [
+                'reference' => '//server/share/releases/2024/',
+                'access' => '\\server\\share\\releases\\2024\\',
+                'uri' => 'file://server/share/releases/2024/',
+            ],
+        ];
+
+        yield 'unc directory with long path prefix maintains prefix' => [
+            '\\?\\UNC\\server\\share\\archive\\',
+            PathFormat::ACCESS_PATH,
+            [
+                'reference' => '//server/share/archive/',
+                'access' => '\\?\\UNC\\server\\share\\archive\\',
+                'uri' => 'file://server/share/archive/',
+            ],
+        ];
+
+        yield 'windows extended directory keeps prefix when rendering' => [
+            '\\?\\C:\\Projects\\Demo\\',
+            PathFormat::ACCESS_PATH,
+            [
+                'reference' => 'C:/Projects/Demo/',
+                'access' => '\\?\\C:\\Projects\\Demo\\',
+                'uri' => 'file:///C:/Projects/Demo/',
+            ],
+        ];
+
+        yield 'root directory renders consistently' => [
+            '/',
+            PathFormat::REFERENCE_PATH,
+            [
+                'reference' => '/',
+                'access' => '/',
+                'uri' => 'file:////',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider fileRenderingProvider
+     */
+    public function testFileRenderingAcrossFormats(string $input, PathFormat $format, array $expected): void
+    {
+        $file = Path::file($input, $format);
+
+        $this->assertSame($expected['reference'], $file->toString(PathFormat::REFERENCE_PATH));
+        $this->assertSame($expected['access'], $file->toString(PathFormat::ACCESS_PATH));
+        $this->assertSame($expected['uri'], $file->toString(PathFormat::ACCESS_URI));
+    }
+
+    public static function fileRenderingProvider(): iterable
+    {
+        yield 'windows file from reference path' => [
+            'C:/Projects/app/config/app.php',
+            PathFormat::REFERENCE_PATH,
+            [
+                'reference' => 'C:/Projects/app/config/app.php',
+                'access' => 'C:\\Projects\\app\\config\\app.php',
+                'uri' => 'file:///C:/Projects/app/config/app.php',
+            ],
+        ];
+
+        yield 'windows file from access path' => [
+            'C:\\Projects\\app\\config\\app.php',
+            PathFormat::ACCESS_PATH,
+            [
+                'reference' => 'C:/Projects/app/config/app.php',
+                'access' => 'C:\\Projects\\app\\config\\app.php',
+                'uri' => 'file:///C:/Projects/app/config/app.php',
+            ],
+        ];
+
+        yield 'windows file from access uri with spaces' => [
+            'file:///C:/Program%20Files/My%20App/app.exe',
+            PathFormat::ACCESS_URI,
+            [
+                'reference' => 'C:/Program Files/My App/app.exe',
+                'access' => 'C:\\Program Files\\My App\\app.exe',
+                'uri' => 'file:///C:/Program%20Files/My%20App/app.exe',
+            ],
+        ];
+
+        yield 'unc file from reference path' => [
+            '//server/share/app/releases/2024/build.zip',
+            PathFormat::REFERENCE_PATH,
+            [
+                'reference' => '//server/share/app/releases/2024/build.zip',
+                'access' => '\\server\\share\\app\\releases\\2024\\build.zip',
+                'uri' => 'file://server/share/app/releases/2024/build.zip',
+            ],
+        ];
+
+        yield 'unc file from access path with unicode characters' => [
+            '\\server\\share\\data\\报告.txt',
+            PathFormat::ACCESS_PATH,
+            [
+                'reference' => '//server/share/data/报告.txt',
+                'access' => '\\server\\share\\data\\\u{62A5}\u{544A}.txt',
+                'uri' => 'file://server/share/data/%E6%8A%A5%E5%91%8A.txt',
+            ],
+        ];
+
+        yield 'unc file from access uri' => [
+            'file://server/share/releases/2024/build.zip',
+            PathFormat::ACCESS_URI,
+            [
+                'reference' => '//server/share/releases/2024/build.zip',
+                'access' => '\\server\\share\\releases\\2024\\build.zip',
+                'uri' => 'file://server/share/releases/2024/build.zip',
+            ],
+        ];
+
+        yield 'posix file from reference path with unicode segment' => [
+            '/var/www/html/über-uns.html',
+            PathFormat::REFERENCE_PATH,
+            [
+                'reference' => '/var/www/html/über-uns.html',
+                'access' => '/var/www/html/über-uns.html',
+                'uri' => 'file:///var/www/html/%C3%BCber-uns.html',
+            ],
+        ];
+
+        yield 'posix file from access uri' => [
+            'file:///etc/hosts',
+            PathFormat::ACCESS_URI,
+            [
+                'reference' => '/etc/hosts',
+                'access' => '/etc/hosts',
+                'uri' => 'file:///etc/hosts',
+            ],
+        ];
+    }
+}

--- a/tests/Integration/UrlPathQueryIntegrationTest.php
+++ b/tests/Integration/UrlPathQueryIntegrationTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Tests\Integration;
+
+use Orryv\Path;
+use Orryv\Path\Enums\PathFormat;
+use PHPUnit\Framework\TestCase;
+
+class UrlPathQueryIntegrationTest extends TestCase
+{
+    /**
+     * @dataProvider withQueryProvider
+     */
+    public function testWithQueryAcceptsVariousInputs(callable $factory, array|string|null $query, string $expectedReference, string $expectedAccess): void
+    {
+        $url = $factory();
+
+        $updated = $url->withQuery($query);
+
+        $this->assertSame($expectedReference, $updated->toString(PathFormat::REFERENCE_PATH));
+        $this->assertSame($expectedAccess, $updated->toString(PathFormat::ACCESS_URI));
+    }
+
+    public static function withQueryProvider(): iterable
+    {
+        yield 'array input with nested parameters' => [
+            static fn () => Path::url('https://example.com/app/index.php', PathFormat::REFERENCE_PATH),
+            ['foo' => 'bar', 'filter' => ['status' => 'active']],
+            'https://example.com/app/index.php?foo=bar&filter[status]=active',
+            'https://example.com/app/index.php?foo=bar&filter%5Bstatus%5D=active',
+        ];
+
+        yield 'string input preserves ordering' => [
+            static fn () => Path::url('https://example.com/app/index.php', PathFormat::REFERENCE_PATH),
+            'b=2&a=1',
+            'https://example.com/app/index.php?b=2&a=1',
+            'https://example.com/app/index.php?b=2&a=1',
+        ];
+
+        yield 'reference string with spaces and unicode is encoded' => [
+            static fn () => Path::url('https://example.com/app/index.php', PathFormat::REFERENCE_PATH),
+            'status=needs review&token=α',
+            'https://example.com/app/index.php?status=needs review&token=α',
+            'https://example.com/app/index.php?status=needs%20review&token=%CE%B1',
+        ];
+
+        yield 'null clears the existing query' => [
+            static fn () => Path::url('https://example.com/app/index.php?foo=bar', PathFormat::REFERENCE_PATH),
+            null,
+            'https://example.com/app/index.php',
+            'https://example.com/app/index.php',
+        ];
+
+        yield 'empty array removes query parameters' => [
+            static fn () => Path::url('https://example.com/app/index.php?foo=bar', PathFormat::REFERENCE_PATH),
+            [],
+            'https://example.com/app/index.php',
+            'https://example.com/app/index.php',
+        ];
+    }
+
+    /**
+     * @dataProvider withoutQueryProvider
+     */
+    public function testWithoutQueryRemovesKeys(callable $factory, array|string|null $keys, string $expectedReference, string $expectedAccess): void
+    {
+        $url = $factory();
+
+        $updated = $url->withoutQuery($keys);
+
+        $this->assertSame($expectedReference, $updated->toString(PathFormat::REFERENCE_PATH));
+        $this->assertSame($expectedAccess, $updated->toString(PathFormat::ACCESS_URI));
+    }
+
+    public static function withoutQueryProvider(): iterable
+    {
+        yield 'remove single key' => [
+            static fn () => Path::url('https://example.com/app/index.php?token=1&lang=en', PathFormat::REFERENCE_PATH),
+            'token',
+            'https://example.com/app/index.php?lang=en',
+            'https://example.com/app/index.php?lang=en',
+        ];
+
+        yield 'remove multiple keys with base key matching' => [
+            static fn () => Path::url('https://example.com/app/index.php?filter[name]=x&filter[age]=y&page=2', PathFormat::REFERENCE_PATH),
+            ['filter', 'page'],
+            'https://example.com/app/index.php',
+            'https://example.com/app/index.php',
+        ];
+
+        yield 'null clears entire query string' => [
+            static fn () => Path::url('https://example.com/app/index.php?foo=bar', PathFormat::REFERENCE_PATH),
+            null,
+            'https://example.com/app/index.php',
+            'https://example.com/app/index.php',
+        ];
+
+        yield 'empty array keeps existing query' => [
+            static fn () => Path::url('https://example.com/app/index.php?foo=bar&lang=en', PathFormat::REFERENCE_PATH),
+            [],
+            'https://example.com/app/index.php?foo=bar&lang=en',
+            'https://example.com/app/index.php?foo=bar&lang=en',
+        ];
+    }
+
+    public function testWithBaseDirNullAllowsUnrestrictedNavigation(): void
+    {
+        $base = Path::url('https://example.com/app/', PathFormat::REFERENCE_PATH);
+        $asset = Path::url('https://example.com/app/assets/css/app.css', PathFormat::REFERENCE_PATH)->withBaseDir($base);
+
+        $unrestricted = $asset->withBaseDir(null);
+        $result = $unrestricted->cd('../../../index.html');
+
+        $this->assertSame('https://example.com/index.html', $result->toString(PathFormat::REFERENCE_PATH));
+        $this->assertSame('https://example.com/index.html', $result->toString(PathFormat::ACCESS_URI));
+    }
+}


### PR DESCRIPTION
## Summary
- add filesystem integration tests covering directory and file rendering across all path formats
- extend relative path integration tests for access path, access URI, and common base scenarios
- add URL query handling integration tests for withQuery/withoutQuery and base directory removal

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68f984d45760832f839b154692b97cb1